### PR TITLE
Fix sketch upload script

### DIFF
--- a/mtk-linkit/files/usr/bin/run-avrdude
+++ b/mtk-linkit/files/usr/bin/run-avrdude
@@ -2,5 +2,4 @@
 
 mt7688_pinmux set spi_s gpio
 
-#avrdude -c linuxgpio -C /etc/avrdude.conf -p m32u4 -U lfuse:w:0xFF:m -U hfuse:w:0xD8:m -U efuse:w:0xFE:m -Uflash:w:$1:i $2
-avrdude -c linuxgpio -C /etc/avrdude.conf -p m32u4 -U flash:w:/etc/arduino/Caterina-smart7688.hex -Uflash:w:$1 $2
+avrdude -c linuxgpio -C /etc/avrdude.conf -p m32u4 -e -v -Uflash:w:$1 $2


### PR DESCRIPTION
The sketch upload script (run-avrdude) burns bootloader and the combined binary file. The hex file upload by Arduino IDE already combine the bootloader with code so don't need to burn bootloader first, also avrdude doesn't clear the chip fist and in some cases this will cause verification fail.

So the parameter for avrdude can simply change to `avrdude -c linuxgpio -C /etc/avrdude.conf -p m32u4 -e -v -Uflash:w:$1 $2`

This is follow-up of  #11.